### PR TITLE
Add php-5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "omnipay/common": "~2.0",
-        "braintree/braintree_php": "^3.1"
+        "braintree/braintree_php": "^2.0"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6901e35c1cf24ac2ae7e84711ed12133",
+    "hash": "b6682e3ca503845002dfd44cf01c25fb",
+    "content-hash": "a6ecd442b74b68c8f94a1da889043496",
     "packages": [
         {
             "name": "braintree/braintree_php",
-            "version": "3.1.0",
+            "version": "2.40.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/braintree/braintree_php.git",
-                "reference": "33144ee8bbb3a1cec9f67078886814278c310981"
+                "reference": "acd947620ede287b4f3b367435ddfc68a2e44e13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/braintree/braintree_php/zipball/33144ee8bbb3a1cec9f67078886814278c310981",
-                "reference": "33144ee8bbb3a1cec9f67078886814278c310981",
+                "url": "https://api.github.com/repos/braintree/braintree_php/zipball/acd947620ede287b4f3b367435ddfc68a2e44e13",
+                "reference": "acd947620ede287b4f3b367435ddfc68a2e44e13",
                 "shasum": ""
             },
             "require": {
@@ -25,8 +26,9 @@
                 "ext-dom": "*",
                 "ext-hash": "*",
                 "ext-openssl": "*",
+                "ext-simplexml": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
+                "php": ">=5.2.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "3.7.*"
@@ -48,7 +50,7 @@
                 }
             ],
             "description": "Braintree PHP Client Library",
-            "time": "2015-06-26 20:09:18"
+            "time": "2015-05-14 19:52:42"
         },
         {
             "name": "guzzle/guzzle",
@@ -263,16 +265,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.2",
+            "version": "v2.7.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3"
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
-                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
+                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
                 "shasum": ""
             },
             "require": {
@@ -317,20 +319,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-18 19:21:56"
+            "time": "2015-09-22 13:49:29"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.7.2",
+            "version": "v2.7.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/HttpFoundation.git",
-                "reference": "88903c0531b90d4ecd90282b18f08c0c77bde0b2"
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "e1509119f164a0d0a940d7d924d693a7a28a5470"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/88903c0531b90d4ecd90282b18f08c0c77bde0b2",
-                "reference": "88903c0531b90d4ecd90282b18f08c0c77bde0b2",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e1509119f164a0d0a940d7d924d693a7a28a5470",
+                "reference": "e1509119f164a0d0a940d7d924d693a7a28a5470",
                 "shasum": ""
             },
             "require": {
@@ -370,7 +372,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:07:40"
+            "time": "2015-09-22 13:49:29"
         }
     ],
     "packages-dev": [
@@ -604,16 +606,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb"
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a923bb15680d0089e2316f7a4af8f437046e96bb",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
                 "shasum": ""
             },
             "require": {
@@ -647,7 +649,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-04-02 05:19:05"
+            "time": "2015-06-21 13:08:43"
         },
         {
             "name": "phpunit/php-text-template",
@@ -692,16 +694,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d"
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/83fe1bdc5d47658b727595c14da140da92b3d66d",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
                 "shasum": ""
             },
             "require": {
@@ -729,7 +731,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-13 07:35:30"
+            "time": "2015-06-21 08:01:12"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -980,16 +982,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.2",
+            "version": "v2.7.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "4bfbe0ed3909bfddd75b70c094391ec1f142f860"
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4bfbe0ed3909bfddd75b70c094391ec1f142f860",
-                "reference": "4bfbe0ed3909bfddd75b70c094391ec1f142f860",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
+                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
                 "shasum": ""
             },
             "require": {
@@ -1025,7 +1027,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-01 11:25:50"
+            "time": "2015-09-14 14:14:09"
         }
     ],
     "aliases": [],

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -15,7 +15,7 @@ class AuthorizeRequest extends AbstractRequest
     {
         $this->validate('amount');
 
-        $data = [
+        $data = array(
             'amount' => $this->getAmount(),
             'billingAddressId' => $this->getBillingAddressId(),
             'channel' => $this->getChannel(),
@@ -31,7 +31,7 @@ class AuthorizeRequest extends AbstractRequest
             'shippingAddressId' => $this->getShippingAddressId(),
             'taxAmount' => $this->getTaxAmount(),
             'taxExempt' => $this->getTaxExempt(),
-        ];
+        );
 
         // special validation
         if ($this->getPaymentMethodToken()) {

--- a/src/Message/ClientTokenRequest.php
+++ b/src/Message/ClientTokenRequest.php
@@ -12,7 +12,7 @@ class ClientTokenRequest extends AbstractRequest
 {
     public function getData()
     {
-        $data = [];
+        $data = array();
         if ($customerId = $this->getCustomerId()) {
             $data['customerId'] = $customerId;
         }

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -38,7 +38,7 @@ class AbstractRequestTest extends TestCase
             array('privateKey', 'abc123'),
             array('billingAddressId', 'abc123'),
             array('channel', 'abc123'),
-            array('customFields', ['a' => 'b']),
+            array('customFields', array('a' => 'b')),
             array('customerId', 'abc123'),
             array('descriptor', array('a' => 'b')),
             array('deviceData', 'abc123'),
@@ -129,7 +129,7 @@ class AbstractRequestTest extends TestCase
 
     public function testOptionData()
     {
-        $options = [
+        $options = array(
             'addBillingAddressToPaymentMethod' => false,
             'makeDefault'                      => true,
             'failOnDuplicatePaymentMethod'     => true,
@@ -139,7 +139,7 @@ class AbstractRequestTest extends TestCase
             'storeShippingAddressInVault'      => true,
             'verifyCard'                       => false,
             'verificationMerchantAccountId'    => true,
-        ];
+        );
         $this->request->initialize($options);
         $data = $this->request->getOptionData();
 

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -23,10 +23,10 @@ class AuthorizeRequestTest extends TestCase
                 'transactionId' => '684',
                 'testMode' => false,
                 'taxExempt' => false,
-                'card' => [
+                'card' => array(
                     'firstName' => 'Kayla',
                     'shippingCompany' => 'League',
-                ]
+                )
             )
         );
     }
@@ -59,10 +59,10 @@ class AuthorizeRequestTest extends TestCase
                 'transactionId' => '684',
                 'testMode' => false,
                 'taxExempt' => false,
-                'card' => [
+                'card' => array(
                     'firstName' => 'Kayla',
                     'shippingCompany' => 'League',
-                ],
+                ),
                 'paymentMethodToken' => 'fake-token-123'
             )
         );
@@ -80,10 +80,10 @@ class AuthorizeRequestTest extends TestCase
                 'transactionId' => '684',
                 'testMode' => false,
                 'taxExempt' => false,
-                'card' => [
+                'card' => array(
                     'firstName' => 'Kayla',
                     'shippingCompany' => 'League',
-                ],
+                ),
                 'paymentMethodNonce' => 'abc123'
             )
         );


### PR DESCRIPTION
Is there any particular reason to not support php-5.3? As omnipay supports it I think gateways should support it as well if possible.