### PR TITLE
Add Plans Api request and response messages.

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -251,6 +251,14 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * @return \Omnipay\Common\Message\PlansRequest
+     */
+    public function plans()
+    {
+        return $this->createRequest('\Omnipay\Braintree\Message\PlanRequest', array());
+    }
+
+    /**
      * @param array $parameters
      *
      * @return \Braintree_WebhookNotification

--- a/src/Message/PlanRequest.php
+++ b/src/Message/PlanRequest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * PlanRequest Class
+ */
+
+namespace Omnipay\Braintree\Message;
+
+class PlanRequest extends AbstractRequest
+{
+    /**
+     * @return null
+     */
+    public function getData()
+    {
+        return null;
+    }
+
+    /**
+     * @param null $data
+     * @return PlanResponse
+     */
+    public function sendData($data = null)
+    {
+        $response = $this->braintree->plan()->all();
+        return $this->response = new PlanResponse($this, $response);
+    }
+}

--- a/src/Message/PlanResponse.php
+++ b/src/Message/PlanResponse.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * PlanResponse class
+ */
+namespace Omnipay\Braintree\Message;
+
+
+class PlanResponse extends Response
+{
+    /**
+     * Returns array of Braintree_Plans objects with available plans
+     * If there aren't any plans created it will return empty array
+     * @return array
+     */
+    public function getPlansData()
+    {
+        if (isset($this->data)) {
+            return $this->data;
+        }
+        return array();
+    }
+}

--- a/tests/Message/PlanRequestTest.php
+++ b/tests/Message/PlanRequestTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: xobb
+ * Date: 1/22/16
+ * Time: 5:53 PM
+ */
+
+namespace Omnipay\Braintree\Message;
+
+use Omnipay\Tests\TestCase;
+
+class PlanRequestTest extends TestCase
+{
+    /** @var PlanRequest */
+    private $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $gateway = $this->buildMockGateway();
+        $this->request = new PlanRequest($this->getHttpClient(), $this->getHttpRequest(), $gateway);
+        $this->request->initialize(array());
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertNull($data);
+    }
+
+    public function testSendData()
+    {
+        $data = array();
+        $response = $this->request->sendData($data);
+
+        $this->assertInstanceOf('Omnipay\BrainTree\Message\PlanResponse', $response);
+    }
+
+    protected function buildMockGateway()
+    {
+        $gateway = $this->getMockBuilder('\Braintree_Gateway')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'plan'
+            ))
+            ->getMock();
+
+        $plan = $this->getMockBuilder('\Braintree_PlanGateway')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $gateway->expects($this->any())
+            ->method('plan')
+            ->will($this->returnValue($plan));
+
+        return $gateway;
+    }
+}

--- a/tests/Message/PlanResponseTest.php
+++ b/tests/Message/PlanResponseTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: xobb
+ * Date: 1/22/16
+ * Time: 5:53 PM
+ */
+
+namespace Omnipay\Braintree\Message;
+use Omnipay\Tests\TestCase;
+
+class PlanResponseTest extends TestCase
+{
+    /** @var  PlanRequest */
+    private $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = new PlanRequest(
+            $this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway()
+        );
+    }
+
+    public function testGetPlansData()
+    {
+        $data = null;
+
+        $response = new PlanResponse($this->request, $data);
+        $this->assertTrue(is_array($response->getPlansData()));
+        $this->assertTrue(count($response->getPlansData()) === 0);
+
+        $data = "planData";
+
+        $response = new PlanResponse($this->request, $data);
+        $this->assertEquals('planData', $response->getPlansData());
+    }
+}


### PR DESCRIPTION
Add fetching the Plans from BrainTree. This is useful when you want to display custom pricing table based on BrainTree plans and when creating subscriptions.