### PR TITLE
add 'cardholderName' to AuthorizeRequest and CreatePaymentMethodRequest

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -48,6 +48,12 @@ class AuthorizeRequest extends AbstractRequest
             return ! is_null($value);
         });
 
+        if ($this->getCardholderName()) {
+            $data['creditCard'] = array(
+                'cardholderName' => $this->getCardholderName(),
+            );
+        }
+
         $data += $this->getOptionData();
         $data += $this->getCardData();
         $data['options']['submitForSettlement'] = false;
@@ -66,5 +72,25 @@ class AuthorizeRequest extends AbstractRequest
         $response = $this->braintree->transaction()->sale($data);
 
         return $this->createResponse($response);
+    }
+
+    /**
+     * [optional] The cardholder name associated with the credit card. 175 character maximum.
+     * Required for iOS integration because its missing in "tokenizeCard" function there.
+     * See: https://developers.braintreepayments.com/reference/request/transaction/sale/php#credit_card.cardholder_name
+     *
+     * @param $value
+     * @return mixed
+     */
+    public function setCardholderName($value)
+    {
+        $cardholderName = trim($value);
+        $cardholderName = strlen($cardholderName)>0 ? $cardholderName : null;
+        return $this->setParameter('cardholderName', $cardholderName);
+    }
+
+    public function getCardholderName()
+    {
+        return $this->getParameter('cardholderName');
     }
 }

--- a/src/Message/CreatePaymentMethodRequest.php
+++ b/src/Message/CreatePaymentMethodRequest.php
@@ -14,6 +14,7 @@ class CreatePaymentMethodRequest extends AbstractRequest
     public function getData()
     {
         $data = array(
+            'cardholderName' => $this->getCardholderName(),
             'customerId' => $this->getCustomerId(),
             'paymentMethodNonce' => $this->getToken(),
         );
@@ -33,5 +34,25 @@ class CreatePaymentMethodRequest extends AbstractRequest
         $response = $this->braintree->paymentMethod()->create($data);
 
         return $this->createResponse($response);
+    }
+
+    /**
+     * [optional] The cardholder name associated with the credit card. 175 character maximum.
+     * Required for iOS integration because its missing in "tokenizeCard" function there.
+     * See: https://developers.braintreepayments.com/reference/request/payment-method/create/php#cardholder_name
+     *
+     * @param $value
+     * @return mixed
+     */
+    public function setCardholderName($value)
+    {
+        $cardholderName = trim($value);
+        $cardholderName = strlen($cardholderName)>0 ? $cardholderName : null;
+        return $this->setParameter('cardholderName', $cardholderName);
+    }
+
+    public function getCardholderName()
+    {
+        return $this->getParameter('cardholderName');
     }
 }

--- a/src/Message/CreatePaymentMethodRequest.php
+++ b/src/Message/CreatePaymentMethodRequest.php
@@ -14,10 +14,12 @@ class CreatePaymentMethodRequest extends AbstractRequest
     public function getData()
     {
         $data = array(
-            'cardholderName' => $this->getCardholderName(),
             'customerId' => $this->getCustomerId(),
             'paymentMethodNonce' => $this->getToken(),
         );
+        if ($cardholderName = $this->getCardholderName()) {
+            $data['cardholderName'] = $cardholderName;
+        }
         $data += $this->getOptionData();
 
         return $data;

--- a/tests/Message/CreatePaymentMethodRequestTest.php
+++ b/tests/Message/CreatePaymentMethodRequestTest.php
@@ -6,15 +6,10 @@ use Omnipay\Tests\TestCase;
 
 class CreatePaymentMethodRequestTest extends TestCase
 {
-    /**
-     * @var CreatePaymentMethodRequest
-     */
-    private $request;
-
-    public function setUp()
+    public function testGetData()
     {
-        $this->request = new CreatePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
-        $this->request->initialize(
+        $request = $this->createPaymentMethodRequest();
+        $request->initialize(
             array(
                 'customerId' => '4815162342',
                 'token' => 'abc123',
@@ -22,10 +17,7 @@ class CreatePaymentMethodRequestTest extends TestCase
                 'verificationMerchantAccountId' => '123581321',
             )
         );
-    }
 
-    public function testGetData()
-    {
         $expectedData = array(
             'customerId' => '4815162342',
             'paymentMethodNonce' => 'abc123',
@@ -34,6 +26,39 @@ class CreatePaymentMethodRequestTest extends TestCase
                 'verificationMerchantAccountId' => '123581321',
             )
         );
-        $this->assertSame($expectedData, $this->request->getData());
+        $this->assertSame($expectedData, $request->getData());
+    }
+
+    public function testGetDataWithCardholderName()
+    {
+        $request = $this->createPaymentMethodRequest();
+        $request->initialize(
+            array(
+                'customerId' => '4815162342',
+                'token' => 'abc123',
+                'cardholderName' => 'John Yolo',
+                'verifyCard' => true,
+                'verificationMerchantAccountId' => '123581321',
+            )
+        );
+
+        $expectedData = array(
+            'customerId' => '4815162342',
+            'paymentMethodNonce' => 'abc123',
+            'cardholderName' => 'John Yolo',
+            'options' => array(
+                'verifyCard' => true,
+                'verificationMerchantAccountId' => '123581321',
+            )
+        );
+        $this->assertSame($expectedData, $request->getData());
+    }
+
+    /**
+     * @return CreatePaymentMethodRequest
+     */
+    private function createPaymentMethodRequest()
+    {
+        return new CreatePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
     }
 }


### PR DESCRIPTION
Added 'cardholderName' to AuthorizeRequest and CreatePaymentMethodRequest
Its required for iOS integration because its missing in "tokenizeCard" function there.