### PR TITLE
Search for transactions

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -290,4 +290,22 @@ class Gateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\Braintree\Message\FindRequest', $parameters);
     }
+
+    /**
+     * Find transactions by criteria
+     *
+     * Example usage:
+     *
+     *      $collections = $brainTree->findTransactions(['customerId' => '12345678']);
+     *
+     * The parameter key has to one of the static methods from \Braintree\TransactionSearch
+     * @see https://developers.braintreepayments.com/reference/request/transaction/search/php
+     *
+     * @param array $parameters
+     * @return mixed|\Omnipay\Common\Message\AbstractRequest
+     */
+    public function findTransactions(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Braintree\Message\FindTransactions', $parameters);
+    }
 }

--- a/src/Message/FindTransactions.php
+++ b/src/Message/FindTransactions.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Omnipay\Braintree\Message;
+
+use Omnipay\Common\Message\ResponseInterface;
+
+class FindTransactions extends AbstractRequest
+{
+    public function getData()
+    {
+        $parameters = $this->getParameters();
+
+        $data = array();
+
+        foreach ($parameters as $parameterName => $value) {
+            if (method_exists('Braintree_TransactionSearch', $parameterName)) {
+                $search = call_user_func("\Braintree_TransactionSearch::$parameterName");
+                $data[] = $search->is($value);
+            }
+        }
+        return $data;
+    }
+
+    public function sendData($data)
+    {
+        $response = $this->braintree->transaction()->search($data);
+
+        return $this->createResponse($response);
+    }
+}


### PR DESCRIPTION
Currently implemented on ```->is()``` criteria.

Works for me for now. If I find a need to search for transaction with [other conditions available](https://developers.braintreepayments.com/reference/general/searching/search-fields/php) I will come up with something more viable.

Well, the tests are missing.