### PR TITLE
Allow authorize request with customerId instead of token or nonce

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -37,10 +37,12 @@ class AuthorizeRequest extends AbstractRequest
         // special validation
         if ($this->getPaymentMethodToken()) {
             $data['paymentMethodToken'] = $this->getPaymentMethodToken();
-        } elseif($this->getToken()) {
+        } elseif ($this->getToken()) {
             $data['paymentMethodNonce'] = $this->getToken();
+        } elseif ($this->getCustomerId()) {
+            $data['customerId'] = $this->getCustomerId();
         } else {
-            throw new InvalidRequestException("The token (payment nonce) or paymentMethodToken field should be set.");
+            throw new InvalidRequestException("The token (payment nonce), paymentMethodToken or customerId field should be set.");
         }
 
         // Remove null values

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -87,7 +87,12 @@ class AuthorizeRequestTest extends TestCase
                 'paymentMethodNonce' => 'abc123'
             )
         );
-    
+
+        $data = $this->request->getData();
+        $this->assertSame('abc123', $data['paymentMethodNonce']);
+        $this->assertArrayNotHasKey('paymentMethodToken', $data);
+    }
+
     public function testCustomerId()
     {
         $this->request->initialize(
@@ -106,12 +111,8 @@ class AuthorizeRequestTest extends TestCase
 
         $data = $this->request->getData();
         $this->assertSame('abc123', $data['customerId']);
-        $this->assertArrayNotHasKey('customerId', $data);
-    }
-
-        $data = $this->request->getData();
-        $this->assertSame('abc123', $data['paymentMethodNonce']);
         $this->assertArrayNotHasKey('paymentMethodToken', $data);
+        $this->assertArrayNotHasKey('paymentMethodNonce', $data);
     }
 
     public function testSubMerchantSale()

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -87,6 +87,27 @@ class AuthorizeRequestTest extends TestCase
                 'paymentMethodNonce' => 'abc123'
             )
         );
+    
+    public function testCustomerId()
+    {
+        $this->request->initialize(
+            array(
+                'amount' => '10.00',
+                'transactionId' => '684',
+                'testMode' => false,
+                'taxExempt' => false,
+                'card' => array(
+                    'firstName' => 'Kayla',
+                    'shippingCompany' => 'League',
+                ),
+                'customerId' => 'abc123'
+            )
+        );
+
+        $data = $this->request->getData();
+        $this->assertSame('abc123', $data['customerId']);
+        $this->assertArrayNotHasKey('customerId', $data);
+    }
 
         $data = $this->request->getData();
         $this->assertSame('abc123', $data['paymentMethodNonce']);


### PR DESCRIPTION
Use customer's default payment already saved in vault.
https://developers.braintreepayments.com/guides/transactions/php