### PR TITLE
Update payment fix

### DIFF
--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="" />
+</component>

--- a/README.md
+++ b/README.md
@@ -69,6 +69,31 @@ $customer = $gateway->findCustomer(1)->send();
 ```
 You can find full list of options [here](https://developers.braintreepayments.com/reference/request/customer/find/php)
 
+### Create payment method
+
+```php
+$method = $gateway->createPaymentMethod([
+    'customerId' => $user->getId(),
+    'paymentMethodNonce' => 'paymentnonce',
+    'options' => [
+        'verifyCard' => true
+    ]
+]);
+```
+You can find full list of options [here](https://developers.braintreepayments.com/reference/request/payment-method/create/php).
+
+### Update payment method
+
+```php
+$method = $gateway->updatePaymentMethod([
+    'paymentMethodToken' => 'token123',
+    'options' => [
+        'paymentMethodNonce' => 'paymentnonce'
+    ]
+]);
+```
+You can find full list of options [here](https://developers.braintreepayments.com/reference/request/payment-method/update/php).
+
 ###Create subscription
 
 ```php

--- a/src/Message/UpdatePaymentMethodRequest.php
+++ b/src/Message/UpdatePaymentMethodRequest.php
@@ -15,7 +15,11 @@ class UpdatePaymentMethodRequest extends AbstractRequest
     {
         $data = array();
         $data['token'] = $this->getToken();
-        $data['parameters'] = $this->parameters->get('paymentMethodOptions');
+        $options = $this->parameters->get('paymentMethodOptions');
+
+        if (null !== $options) {
+            $data['options'] = $options;
+        }
 
         return $data;
     }
@@ -28,7 +32,7 @@ class UpdatePaymentMethodRequest extends AbstractRequest
      */
     public function sendData($data)
     {
-        $response = $this->braintree->paymentMethod()->update($data['token'], $data['parameters']);
+        $response = $this->braintree->paymentMethod()->update($data['token'], $data['options']);
 
         return $this->createResponse($response);
     }

--- a/src/Message/UpdatePaymentMethodRequest.php
+++ b/src/Message/UpdatePaymentMethodRequest.php
@@ -13,13 +13,9 @@ class UpdatePaymentMethodRequest extends AbstractRequest
 {
     public function getData()
     {
-        $parameters = array();
-        $parameters += $this->getOptionData();
-
+        $data = array();
         $data['token'] = $this->getToken();
-        if (!empty($parameters)) {
-            $data['parameters'] = $parameters;
-        }
+        $data['parameters'] = $this->parameters->get('paymentMethodOptions');
 
         return $data;
     }
@@ -35,5 +31,25 @@ class UpdatePaymentMethodRequest extends AbstractRequest
         $response = $this->braintree->paymentMethod()->update($data['token'], $data['parameters']);
 
         return $this->createResponse($response);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setPaymentMethodToken($value)
+    {
+        return $this->setParameter('token', $value);
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setOptions(array $options = array())
+    {
+        return $this->setParameter('paymentMethodOptions', $options);
     }
 }

--- a/tests/Message/UpdatePaymentMethodRequestTest.php
+++ b/tests/Message/UpdatePaymentMethodRequestTest.php
@@ -20,16 +20,16 @@ class UpdatePaymentMethodRequestTest extends TestCase
     {
         $this->request->initialize(
             array(
-                'token' => 'abcd1234',
-                'makeDefault' => true,
+                'paymentMethodToken' => 'abcd1234',
+                'options' => array(
+                    'makeDefault' => true,
+                )
             )
         );
         $expected = array(
             'token' => 'abcd1234',
-            'parameters' => array(
-                'options' => array(
-                    'makeDefault' => true,
-                ),
+            'options' => array(
+                'makeDefault' => true,
             ),
         );
         $this->assertSame($expected, $this->request->getData());
@@ -39,7 +39,7 @@ class UpdatePaymentMethodRequestTest extends TestCase
     {
         $this->request->initialize(
             array(
-                'token' => 'abcd1234',
+                'paymentMethodToken' => 'abcd1234',
             )
         );
         $expected = array(


### PR DESCRIPTION
Change update payment request in order to accept all available parameters of Braintree SDK and not just these in AbstractRequest::getOptionsData().
Also, an example of create and one of update payment method was added in README.