### PR TITLE
Updates to use current 5.x Braintree SDK and PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Omnipay is installed via [Composer](http://getcomposer.org/). To install, simply
 to your `composer.json` file:
 
 ```
-composer require omnipay/braintree:"~3.0@dev"
+composer require omnipay/braintree:"~4.0@dev"
 ```
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Total Downloads](https://poser.pugx.org/omnipay/braintree/d/total.png)](https://packagist.org/packages/omnipay/braintree)
 
 [Omnipay](https://github.com/thephpleague/omnipay) is a framework agnostic, multi-gateway payment
-processing library for PHP 5.3+. This package implements Braintree support for Omnipay.
+processing library for PHP 7.2+. This package implements Braintree support for Omnipay.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "omnipay/common": "^3",
-        "braintree/braintree_php": "^3.0"
+        "braintree/braintree_php": "^5.0"
     },
     "require-dev": {
         "omnipay/tests": "^3"

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -2,9 +2,10 @@
 
 namespace Omnipay\Braintree;
 
+use Braintree\Gateway as BraintreeGateway;
+use Braintree\Configuration;
+use Braintree\WebhookNotification;
 use Omnipay\Common\AbstractGateway;
-use Braintree_Gateway;
-use Braintree_Configuration;
 use Omnipay\Common\Http\ClientInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 /**
@@ -13,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 class Gateway extends AbstractGateway
 {
     /**
-     * @var \Braintree_Gateway
+     * @var BraintreeGateway
      */
     protected $braintree;
 
@@ -22,11 +23,11 @@ class Gateway extends AbstractGateway
      *
      * @param ClientInterface $httpClient  A Guzzle client to make API calls with
      * @param HttpRequest     $httpRequest A Symfony HTTP request object
-     * @param Braintree_Gateway $braintree The Braintree gateway
+     * @param BraintreeGateway $braintree The Braintree gateway
      */
-    public function __construct(ClientInterface $httpClient = null, HttpRequest $httpRequest = null, Braintree_Gateway $braintree = null)
+    public function __construct(ClientInterface $httpClient = null, HttpRequest $httpRequest = null, BraintreeGateway $braintree = null)
     {
-        $this->braintree = $braintree ?: Braintree_Configuration::gateway();
+        $this->braintree = $braintree ?: Configuration::gateway();
 
         parent::__construct($httpClient, $httpRequest);
     }
@@ -270,13 +271,13 @@ class Gateway extends AbstractGateway
     /**
      * @param array $parameters
      *
-     * @return \Braintree_WebhookNotification
+     * @return WebhookNotification
      *
-     * @throws \Braintree_Exception_InvalidSignature
+     * @throws \Braintree\Exception\InvalidSignature
      */
     public function parseNotification(array $parameters = array())
     {
-        return \Braintree_WebhookNotification::parse(
+        return WebhookNotification::parse(
             $parameters['bt_signature'],
             $parameters['bt_payload']
         );

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -2,14 +2,14 @@
 
 namespace Omnipay\Braintree;
 
-use Braintree\Gateway as BraintreeGateway;
 use Braintree\Configuration;
+use Braintree\Gateway as BraintreeGateway;
 use Braintree\WebhookNotification;
 use Omnipay\Common\AbstractGateway;
 use Omnipay\Common\Http\ClientInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 /**
- * Braintree Gateway
+ * Braintree Gateway.
  */
 class Gateway extends AbstractGateway
 {
@@ -19,11 +19,11 @@ class Gateway extends AbstractGateway
     protected $braintree;
 
     /**
-     * Create a new gateway instance
+     * Create a new gateway instance.
      *
-     * @param ClientInterface $httpClient  A Guzzle client to make API calls with
-     * @param HttpRequest     $httpRequest A Symfony HTTP request object
-     * @param BraintreeGateway $braintree The Braintree gateway
+     * @param ClientInterface  $httpClient  A Guzzle client to make API calls with
+     * @param HttpRequest      $httpRequest A Symfony HTTP request object
+     * @param BraintreeGateway $braintree   The Braintree gateway
      */
     public function __construct(ClientInterface $httpClient = null, HttpRequest $httpRequest = null, BraintreeGateway $braintree = null)
     {
@@ -49,12 +49,12 @@ class Gateway extends AbstractGateway
 
     public function getDefaultParameters()
     {
-        return array(
+        return [
             'merchantId' => '',
             'publicKey' => '',
             'privateKey' => '',
             'testMode' => false,
-        );
+        ];
     }
 
     public function getMerchantId()
@@ -89,33 +89,37 @@ class Gateway extends AbstractGateway
 
     /**
      * @param array $parameters
+     *
      * @return Message\AuthorizeRequest
      */
-    public function authorize(array $parameters = array())
+    public function authorize(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\AuthorizeRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\PurchaseRequest
      */
-    public function capture(array $parameters = array())
+    public function capture(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\CaptureRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\ClientTokenRequest
      */
-    public function clientToken(array $parameters = array())
+    public function clientToken(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\ClientTokenRequest', $parameters);
     }
 
     /**
      * @param string $id
+     *
      * @return Message\FindCustomerRequest
      */
     public function findCustomer($id)
@@ -125,117 +129,130 @@ class Gateway extends AbstractGateway
 
     /**
      * @param array $parameters
+     *
      * @return Message\CreateCustomerRequest
      */
-    public function createCustomer(array $parameters = array())
+    public function createCustomer(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\CreateCustomerRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\DeleteCustomerRequest
      */
-    public function deleteCustomer(array $parameters = array())
+    public function deleteCustomer(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\DeleteCustomerRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\UpdateCustomerRequest
      */
-    public function updateCustomer(array $parameters = array())
+    public function updateCustomer(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\UpdateCustomerRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\PurchaseRequest
      */
-    public function find(array $parameters = array())
+    public function find(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\FindRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\CreateMerchantAccountRequest
      */
-    public function createMerchantAccount(array $parameters = array())
+    public function createMerchantAccount(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\CreateMerchantAccountRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\UpdateMerchantAccountRequest
      */
-    public function updateMerchantAccount(array $parameters = array())
+    public function updateMerchantAccount(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\UpdateMerchantAccountRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\CreatePaymentMethodRequest
      */
-    public function createPaymentMethod(array $parameters = array())
+    public function createPaymentMethod(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\CreatePaymentMethodRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\DeletePaymentMethodRequest
      */
-    public function deletePaymentMethod(array $parameters = array())
+    public function deletePaymentMethod(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\DeletePaymentMethodRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\UpdatePaymentMethodRequest
      */
-    public function updatePaymentMethod(array $parameters = array())
+    public function updatePaymentMethod(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\UpdatePaymentMethodRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\PurchaseRequest
      */
-    public function purchase(array $parameters = array())
+    public function purchase(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\PurchaseRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\PurchaseRequest
      */
-    public function refund(array $parameters = array())
+    public function refund(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\RefundRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\PurchaseRequest
      */
-    public function releaseFromEscrow(array $parameters = array())
+    public function releaseFromEscrow(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\ReleaseFromEscrowRequest', $parameters);
     }
 
     /**
      * @param array $parameters
+     *
      * @return Message\PurchaseRequest
      */
-    public function void(array $parameters = array())
+    public function void(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\VoidRequest', $parameters);
     }
@@ -245,7 +262,7 @@ class Gateway extends AbstractGateway
      *
      * @return \Omnipay\Common\Message\AbstractRequest
      */
-    public function createSubscription(array $parameters = array())
+    public function createSubscription(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\CreateSubscriptionRequest', $parameters);
     }
@@ -265,7 +282,7 @@ class Gateway extends AbstractGateway
      */
     public function plans()
     {
-        return $this->createRequest('\Omnipay\Braintree\Message\PlanRequest', array());
+        return $this->createRequest('\Omnipay\Braintree\Message\PlanRequest', []);
     }
 
     /**
@@ -275,7 +292,7 @@ class Gateway extends AbstractGateway
      *
      * @throws \Braintree\Exception\InvalidSignature
      */
-    public function parseNotification(array $parameters = array())
+    public function parseNotification(array $parameters = [])
     {
         return WebhookNotification::parse(
             $parameters['bt_signature'],
@@ -285,9 +302,10 @@ class Gateway extends AbstractGateway
 
     /**
      * @param array $parameters
+     *
      * @return Message\FindRequest
      */
-    public function fetchTransaction(array $parameters = array())
+    public function fetchTransaction(array $parameters = [])
     {
         return $this->createRequest('\Omnipay\Braintree\Message\FindRequest', $parameters);
     }

--- a/src/Message/AbstractMerchantAccountRequest.php
+++ b/src/Message/AbstractMerchantAccountRequest.php
@@ -25,25 +25,25 @@ abstract class AbstractMerchantAccountRequest extends AbstractRequest
     {
         $business = $this->getBusiness();
 
-        if (!$business) {
-            return array();
+        if (! $business) {
+            return [];
         }
 
-        $data = array(
-            'address' => array(
+        $data = [
+            'address' => [
                 'streetAddress' => $business->getAddress1(),
                 'locality' => $business->getCity(),
                 'postalCode' => $business->getPostCode(),
                 'region' => $business->getState(),
-            ),
+            ],
             'dbaName' => $business->getDbaName(),
             'email' => $business->getEmail(),
             'legalName' => $business->getLegalName(),
             'taxId' => $business->getTaxId(),
-        );
+        ];
 
         // Remove null values
-        $data = array_filter($data, function($value){
+        $data = array_filter($data, function ($value) {
             return ! is_null($value);
         });
 
@@ -58,11 +58,12 @@ abstract class AbstractMerchantAccountRequest extends AbstractRequest
      * Sets the business.
      *
      * @param MerchantBusiness|array $value
+     *
      * @return $this
      */
     public function setBusiness($value)
     {
-        if ($value && !$value instanceof MerchantBusiness) {
+        if ($value && ! $value instanceof MerchantBusiness) {
             $value = new MerchantBusiness($value);
         }
 
@@ -85,28 +86,28 @@ abstract class AbstractMerchantAccountRequest extends AbstractRequest
     {
         $funding = $this->getFunding();
 
-        if (!$funding) {
-            return array();
+        if (! $funding) {
+            return [];
         }
 
-        $data = array(
+        $data = [
             'accountNumber' => $funding->getAccountNumber(),
             'descriptor' => $funding->getDescriptor(),
             'destination' => $funding->getDestination(),
             'email' => $funding->getEmail(),
             'mobilePhone' => $funding->getMobilePhone(),
-            'routingNumber' =>  $funding->getRoutingNumber(),
-        );
+            'routingNumber' => $funding->getRoutingNumber(),
+        ];
 
         // Remove null values
-        $data = array_filter($data, function($value){
+        $data = array_filter($data, function ($value) {
             return ! is_null($value);
         });
 
         if (empty($data)) {
             return $data;
         } else {
-            return array('funding' => $data);
+            return ['funding' => $data];
         }
     }
 
@@ -114,17 +115,18 @@ abstract class AbstractMerchantAccountRequest extends AbstractRequest
      * Sets the funding.
      *
      * @param MerchantFunding|array $value
+     *
      * @return $this
      */
     public function setFunding($value)
     {
-        if ($value && !$value instanceof MerchantFunding) {
+        if ($value && ! $value instanceof MerchantFunding) {
             $value = new MerchantFunding($value);
         }
 
         return $this->setParameter('funding', $value);
     }
-    
+
     /**
      * @return MerchantIndividual
      */
@@ -142,34 +144,34 @@ abstract class AbstractMerchantAccountRequest extends AbstractRequest
     {
         $individual = $this->getIndividual();
 
-        if (!$individual) {
-            return array();
+        if (! $individual) {
+            return [];
         }
 
-        $data = array(
-            'address' => array(
+        $data = [
+            'address' => [
                 'streetAddress' => $individual->getAddress1(),
                 'locality' => $individual->getCity(),
                 'postalCode' => $individual->getPostCode(),
                 'region' => $individual->getState(),
-            ),
+            ],
             'dateOfBirth' => $individual->getBirthday(),
             'email' => $individual->getEmail(),
             'firstName' => $individual->getFirstName(),
             'lastName' => $individual->getLastName(),
             'phone' => $individual->getPhone(),
             'ssn' => $individual->getSsn(),
-        );
+        ];
 
         // Remove null values
-        $data = array_filter($data, function($value){
+        $data = array_filter($data, function ($value) {
             return ! is_null($value);
         });
 
         if (empty($data)) {
             return $data;
         } else {
-            return array('individual' => $data);
+            return ['individual' => $data];
         }
     }
 
@@ -177,11 +179,12 @@ abstract class AbstractMerchantAccountRequest extends AbstractRequest
      * Sets the individual.
      *
      * @param MerchantIndividual|array $value
+     *
      * @return $this
      */
     public function setIndividual($value)
     {
-        if ($value && !$value instanceof MerchantIndividual) {
+        if ($value && ! $value instanceof MerchantIndividual) {
             $value = new MerchantIndividual($value);
         }
 
@@ -198,6 +201,7 @@ abstract class AbstractMerchantAccountRequest extends AbstractRequest
 
     /**
      * @param string $masterMerchantAccountId
+     *
      * @return $this
      */
     public function setMasterMerchantAccountId($masterMerchantAccountId)
@@ -217,6 +221,7 @@ abstract class AbstractMerchantAccountRequest extends AbstractRequest
 
     /**
      * @param bool $tosAccepted
+     *
      * @return $this
      */
     public function setTosAccepted($tosAccepted)

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -3,14 +3,13 @@
 namespace Omnipay\Braintree\Message;
 
 use Braintree\Gateway;
-use Omnipay\Common\Http\ClientInterface;
 use Omnipay\Common\Exception\InvalidRequestException;
-use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Omnipay\Common\Http\ClientInterface;
 use Omnipay\Common\Message\AbstractRequest as BaseAbstractRequest;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 /**
- * Abstract Request
- *
+ * Abstract Request.
  */
 abstract class AbstractRequest extends BaseAbstractRequest
 {
@@ -20,11 +19,11 @@ abstract class AbstractRequest extends BaseAbstractRequest
     protected $braintree;
 
     /**
-     * Create a new Request
+     * Create a new Request.
      *
      * @param ClientInterface $httpClient  A Guzzle client to make API calls with
      * @param HttpRequest     $httpRequest A Symfony HTTP request object
-     * @param Gateway $braintree The Braintree Gateway
+     * @param Gateway         $braintree   The Braintree Gateway
      */
     public function __construct(ClientInterface $httpClient, HttpRequest $httpRequest, Gateway $braintree)
     {
@@ -34,7 +33,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
     }
 
     /**
-     * Set the correct configuration sending
+     * Set the correct configuration sending.
      *
      * @return \Omnipay\Common\Message\ResponseInterface
      */
@@ -214,9 +213,9 @@ abstract class AbstractRequest extends BaseAbstractRequest
     {
         $amount = $this->getParameter('serviceFeeAmount');
         if ($amount !== null) {
-            if (!is_float($amount) &&
+            if (! is_float($amount) &&
                 $this->getCurrencyDecimalPlaces() > 0 &&
-                false === strpos((string)$amount, '.')
+                false === strpos((string) $amount, '.')
             ) {
                 throw new InvalidRequestException(
                     'Please specify amount as a string or float, ' .
@@ -370,17 +369,17 @@ abstract class AbstractRequest extends BaseAbstractRequest
     {
         $card = $this->getCard();
 
-        if (!$card) {
+        if (! $card) {
             return [];
         }
 
-        return array(
+        return [
             'billing' => [
                 'company' => $card->getBillingCompany(),
                 'firstName' => $card->getBillingFirstName(),
                 'lastName' => $card->getBillingLastName(),
                 'streetAddress' => $card->getBillingAddress1(),
-                'extendedAddress' =>  $card->getBillingAddress2(),
+                'extendedAddress' => $card->getBillingAddress2(),
                 'locality' => $card->getBillingCity(),
                 'postalCode' => $card->getBillingPostcode(),
                 'region' => $card->getBillingState(),
@@ -391,13 +390,13 @@ abstract class AbstractRequest extends BaseAbstractRequest
                 'firstName' => $card->getShippingFirstName(),
                 'lastName' => $card->getShippingLastName(),
                 'streetAddress' => $card->getShippingAddress1(),
-                'extendedAddress' =>  $card->getShippingAddress2(),
+                'extendedAddress' => $card->getShippingAddress2(),
                 'locality' => $card->getShippingCity(),
                 'postalCode' => $card->getShippingPostcode(),
                 'region' => $card->getShippingState(),
                 'countryName' => $card->getShippingCountry(),
-            ]
-        );
+            ],
+        ];
     }
 
     /**
@@ -407,18 +406,18 @@ abstract class AbstractRequest extends BaseAbstractRequest
     {
         $data = [
             'addBillingAddressToPaymentMethod' => $this->getAddBillingAddressToPaymentMethod(),
-            'failOnDuplicatePaymentMethod'     => $this->getFailOnDuplicatePaymentMethod(),
-            'holdInEscrow'                     => $this->getHoldInEscrow(),
-            'makeDefault'                      => $this->getMakeDefault(),
-            'storeInVault'                     => $this->getStoreInVault(),
-            'storeInVaultOnSuccess'            => $this->getStoreInVaultOnSuccess(),
-            'storeShippingAddressInVault'      => $this->getStoreShippingAddressInVault(),
-            'verifyCard'                       => $this->getVerifyCard(),
-            'verificationMerchantAccountId'    => $this->getVerificationMerchantAccountId(),
+            'failOnDuplicatePaymentMethod' => $this->getFailOnDuplicatePaymentMethod(),
+            'holdInEscrow' => $this->getHoldInEscrow(),
+            'makeDefault' => $this->getMakeDefault(),
+            'storeInVault' => $this->getStoreInVault(),
+            'storeInVaultOnSuccess' => $this->getStoreInVaultOnSuccess(),
+            'storeShippingAddressInVault' => $this->getStoreShippingAddressInVault(),
+            'verifyCard' => $this->getVerifyCard(),
+            'verificationMerchantAccountId' => $this->getVerificationMerchantAccountId(),
         ];
 
         // Remove null values
-        $data = array_filter($data, function($value) {
+        $data = array_filter($data, function ($value) {
             return ! is_null($value);
         });
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
-use Braintree_Gateway;
+use Braintree\Gateway;
 use Omnipay\Common\Http\ClientInterface;
 use Omnipay\Common\Exception\InvalidRequestException;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
@@ -15,7 +15,7 @@ use Omnipay\Common\Message\AbstractRequest as BaseAbstractRequest;
 abstract class AbstractRequest extends BaseAbstractRequest
 {
     /**
-     * @var \Braintree_Gateway
+     * @var Gateway
      */
     protected $braintree;
 
@@ -24,9 +24,9 @@ abstract class AbstractRequest extends BaseAbstractRequest
      *
      * @param ClientInterface $httpClient  A Guzzle client to make API calls with
      * @param HttpRequest     $httpRequest A Symfony HTTP request object
-     * @param Braintree_Gateway $braintree The Braintree Gateway
+     * @param Gateway $braintree The Braintree Gateway
      */
-    public function __construct(ClientInterface $httpClient, HttpRequest $httpRequest, Braintree_Gateway $braintree)
+    public function __construct(ClientInterface $httpClient, HttpRequest $httpRequest, Gateway $braintree)
     {
         $this->braintree = $braintree;
 
@@ -371,11 +371,11 @@ abstract class AbstractRequest extends BaseAbstractRequest
         $card = $this->getCard();
 
         if (!$card) {
-            return array();
+            return [];
         }
 
         return array(
-            'billing' => array(
+            'billing' => [
                 'company' => $card->getBillingCompany(),
                 'firstName' => $card->getBillingFirstName(),
                 'lastName' => $card->getBillingLastName(),
@@ -385,8 +385,8 @@ abstract class AbstractRequest extends BaseAbstractRequest
                 'postalCode' => $card->getBillingPostcode(),
                 'region' => $card->getBillingState(),
                 'countryName' => $card->getBillingCountry(),
-            ),
-            'shipping' => array(
+            ],
+            'shipping' => [
                 'company' => $card->getShippingCompany(),
                 'firstName' => $card->getShippingFirstName(),
                 'lastName' => $card->getShippingLastName(),
@@ -396,7 +396,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
                 'postalCode' => $card->getShippingPostcode(),
                 'region' => $card->getShippingState(),
                 'countryName' => $card->getShippingCountry(),
-            )
+            ]
         );
     }
 
@@ -405,7 +405,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
      */
     public function getOptionData()
     {
-        $data = array(
+        $data = [
             'addBillingAddressToPaymentMethod' => $this->getAddBillingAddressToPaymentMethod(),
             'failOnDuplicatePaymentMethod'     => $this->getFailOnDuplicatePaymentMethod(),
             'holdInEscrow'                     => $this->getHoldInEscrow(),
@@ -415,17 +415,17 @@ abstract class AbstractRequest extends BaseAbstractRequest
             'storeShippingAddressInVault'      => $this->getStoreShippingAddressInVault(),
             'verifyCard'                       => $this->getVerifyCard(),
             'verificationMerchantAccountId'    => $this->getVerificationMerchantAccountId(),
-        );
+        ];
 
         // Remove null values
-        $data = array_filter($data, function($value){
+        $data = array_filter($data, function($value) {
             return ! is_null($value);
         });
 
         if (empty($data)) {
             return $data;
         } else {
-            return array('options' => $data);
+            return ['options' => $data];
         }
     }
 

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -5,7 +5,7 @@ use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Authorize Request
+ * Authorize Request.
  *
  * @method Response send()
  */
@@ -42,18 +42,18 @@ class AuthorizeRequest extends AbstractRequest
         } elseif ($this->getCustomerId()) {
             $data['customerId'] = $this->getCustomerId();
         } else {
-            throw new InvalidRequestException("The token (payment nonce), paymentMethodToken or customerId field should be set.");
+            throw new InvalidRequestException('The token (payment nonce), paymentMethodToken or customerId field should be set.');
         }
 
         // Remove null values
-        $data = array_filter($data, function($value){
+        $data = array_filter($data, function ($value) {
             return ! is_null($value);
         });
 
         if ($this->getCardholderName()) {
-            $data['creditCard'] = array(
+            $data['creditCard'] = [
                 'cardholderName' => $this->getCardholderName(),
-            );
+            ];
         }
 
         $data += $this->getOptionData();
@@ -64,9 +64,10 @@ class AuthorizeRequest extends AbstractRequest
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)
@@ -79,15 +80,17 @@ class AuthorizeRequest extends AbstractRequest
     /**
      * [optional] The cardholder name associated with the credit card. 175 character maximum.
      * Required for iOS integration because its missing in "tokenizeCard" function there.
-     * See: https://developers.braintreepayments.com/reference/request/transaction/sale/php#credit_card.cardholder_name
+     * See: https://developers.braintreepayments.com/reference/request/transaction/sale/php#credit_card.cardholder_name.
      *
      * @param $value
+     *
      * @return mixed
      */
     public function setCardholderName($value)
     {
         $cardholderName = trim($value);
-        $cardholderName = strlen($cardholderName)>0 ? $cardholderName : null;
+        $cardholderName = strlen($cardholderName) > 0 ? $cardholderName : null;
+
         return $this->setParameter('cardholderName', $cardholderName);
     }
 

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -15,7 +15,7 @@ class AuthorizeRequest extends AbstractRequest
     {
         $this->validate('amount');
 
-        $data = array(
+        $data = [
             'amount' => $this->getAmount(),
             'billingAddressId' => $this->getBillingAddressId(),
             'channel' => $this->getChannel(),
@@ -32,7 +32,7 @@ class AuthorizeRequest extends AbstractRequest
             'shippingAddressId' => $this->getShippingAddressId(),
             'taxAmount' => $this->getTaxAmount(),
             'taxExempt' => $this->getTaxExempt(),
-        );
+        ];
 
         // special validation
         if ($this->getPaymentMethodToken()) {

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -4,7 +4,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Authorize Request
+ * Authorize Request.
  *
  * @method Response send()
  */
@@ -14,16 +14,17 @@ class CaptureRequest extends AbstractRequest
     {
         $this->validate('transactionReference');
 
-        return array(
+        return [
             'transactionReference' => $this->getTransactionReference(),
             'amount' => $this->getAmount(),
-        );
+        ];
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)

--- a/src/Message/ClientTokenRequest.php
+++ b/src/Message/ClientTokenRequest.php
@@ -4,7 +4,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Authorize Request
+ * Authorize Request.
  *
  * @method ClientTokenResponse send()
  */
@@ -12,7 +12,7 @@ class ClientTokenRequest extends AbstractRequest
 {
     public function getData()
     {
-        $data = array();
+        $data = [];
         if ($customerId = $this->getCustomerId()) {
             $data['customerId'] = $customerId;
         }
@@ -22,9 +22,10 @@ class ClientTokenRequest extends AbstractRequest
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)

--- a/src/Message/CreateMerchantAccountRequest.php
+++ b/src/Message/CreateMerchantAccountRequest.php
@@ -4,7 +4,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Merchant account Request
+ * Merchant account Request.
  *
  * @method Response send()
  */
@@ -12,13 +12,13 @@ class CreateMerchantAccountRequest extends AbstractMerchantAccountRequest
 {
     public function getData()
     {
-        $data = array(
+        $data = [
             'id' => $this->getMerchantAccountId(),
             'masterMerchantAccountId' => $this->getMasterMerchantAccountId(),
             'tosAccepted' => $this->getTosAccepted(),
-        );
+        ];
         // Remove null values
-        $data = array_filter($data, function($value){
+        $data = array_filter($data, function ($value) {
             return ! is_null($value);
         });
         $data += $this->getBusinessData() + $this->getFundingData() + $this->getIndividualData();
@@ -27,9 +27,10 @@ class CreateMerchantAccountRequest extends AbstractMerchantAccountRequest
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)

--- a/src/Message/CreatePaymentMethodRequest.php
+++ b/src/Message/CreatePaymentMethodRequest.php
@@ -5,7 +5,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Create PaymentMethod Request
+ * Create PaymentMethod Request.
  *
  * @method Response send()
  */
@@ -13,10 +13,10 @@ class CreatePaymentMethodRequest extends AbstractRequest
 {
     public function getData()
     {
-        $data = array(
+        $data = [
             'customerId' => $this->getCustomerId(),
             'paymentMethodNonce' => $this->getToken(),
-        );
+        ];
         if ($cardholderName = $this->getCardholderName()) {
             $data['cardholderName'] = $cardholderName;
         }
@@ -26,9 +26,10 @@ class CreatePaymentMethodRequest extends AbstractRequest
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)
@@ -41,15 +42,17 @@ class CreatePaymentMethodRequest extends AbstractRequest
     /**
      * [optional] The cardholder name associated with the credit card. 175 character maximum.
      * Required for iOS integration because its missing in "tokenizeCard" function there.
-     * See: https://developers.braintreepayments.com/reference/request/payment-method/create/php#cardholder_name
+     * See: https://developers.braintreepayments.com/reference/request/payment-method/create/php#cardholder_name.
      *
      * @param $value
+     *
      * @return mixed
      */
     public function setCardholderName($value)
     {
         $cardholderName = trim($value);
-        $cardholderName = strlen($cardholderName)>0 ? $cardholderName : null;
+        $cardholderName = strlen($cardholderName) > 0 ? $cardholderName : null;
+
         return $this->setParameter('cardholderName', $cardholderName);
     }
 

--- a/src/Message/FindRequest.php
+++ b/src/Message/FindRequest.php
@@ -4,7 +4,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Authorize Request
+ * Authorize Request.
  *
  * @method Response send()
  */
@@ -14,15 +14,16 @@ class FindRequest extends AbstractRequest
     {
         $this->validate('transactionReference');
 
-        return array(
+        return [
             'transactionReference' => $this->getTransactionReference(),
-        );
+        ];
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)

--- a/src/Message/PlanResponse.php
+++ b/src/Message/PlanResponse.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * PlanResponse class
+ * PlanResponse class.
  */
 namespace Omnipay\Braintree\Message;
-
 
 class PlanResponse extends Response
 {
     /**
      * Returns array of Braintree_Plans objects with available plans
-     * If there aren't any plans created it will return empty array
+     * If there aren't any plans created it will return empty array.
+     *
      * @return array
      */
     public function getPlansData()
@@ -17,6 +17,7 @@ class PlanResponse extends Response
         if (isset($this->data)) {
             return $this->data;
         }
-        return array();
+
+        return [];
     }
 }

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -4,7 +4,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Authorize Request
+ * Authorize Request.
  *
  * @method Response send()
  */
@@ -14,16 +14,17 @@ class RefundRequest extends AbstractRequest
     {
         $this->validate('transactionReference');
 
-        return array(
+        return [
             'transactionReference' => $this->getTransactionReference(),
             'amount' => $this->getAmount(),
-        );
+        ];
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)

--- a/src/Message/ReleaseFromEscrowRequest.php
+++ b/src/Message/ReleaseFromEscrowRequest.php
@@ -5,7 +5,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Authorize Request
+ * Authorize Request.
  *
  * @method Response send()
  */
@@ -15,15 +15,16 @@ class ReleaseFromEscrowRequest extends AbstractRequest
     {
         $this->validate('transactionId');
 
-        return array(
+        return [
             'transactionId' => $this->getTransactionId(),
-        );
+        ];
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)

--- a/src/Message/UpdateCustomerRequest.php
+++ b/src/Message/UpdateCustomerRequest.php
@@ -4,7 +4,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Authorize Request
+ * Authorize Request.
  *
  * @method CustomerResponse send()
  */
@@ -12,16 +12,17 @@ class UpdateCustomerRequest extends AbstractRequest
 {
     public function getData()
     {
-        return array(
+        return [
             'customerData' => $this->getCustomerData(),
             'customerId' => $this->getCustomerId(),
-        );
+        ];
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)

--- a/src/Message/UpdateMerchantAccountRequest.php
+++ b/src/Message/UpdateMerchantAccountRequest.php
@@ -4,7 +4,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Authorize Request
+ * Authorize Request.
  *
  * @method Response send()
  */
@@ -12,16 +12,17 @@ class UpdateMerchantAccountRequest extends AbstractMerchantAccountRequest
 {
     public function getData()
     {
-        return array(
+        return [
             'merchantData' => $this->getBusinessData() + $this->getFundingData() + $this->getIndividualData(),
             'merchantAccountId' => $this->getMerchantAccountId(),
-        );
+        ];
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)

--- a/src/Message/UpdatePaymentMethodRequest.php
+++ b/src/Message/UpdatePaymentMethodRequest.php
@@ -5,14 +5,15 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Update PaymentMethod Request
+ * Update PaymentMethod Request.
+ *
  * @method Response send()
  */
 class UpdatePaymentMethodRequest extends AbstractRequest
 {
     public function getData()
     {
-        $data = array();
+        $data = [];
         $data['token'] = $this->getToken();
         $options = $this->parameters->get('paymentMethodOptions');
 
@@ -24,9 +25,9 @@ class UpdatePaymentMethodRequest extends AbstractRequest
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
      *
      * @return ResponseInterface
      */
@@ -62,7 +63,7 @@ class UpdatePaymentMethodRequest extends AbstractRequest
      *
      * @return \Omnipay\Common\Message\AbstractRequest
      */
-    public function setOptions(array $options = array())
+    public function setOptions(array $options = [])
     {
         return $this->setParameter('paymentMethodOptions', $options);
     }

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -4,7 +4,7 @@ namespace Omnipay\Braintree\Message;
 use Omnipay\Common\Message\ResponseInterface;
 
 /**
- * Authorize Request
+ * Authorize Request.
  *
  * @method Response send()
  */
@@ -14,15 +14,16 @@ class VoidRequest extends AbstractRequest
     {
         $this->validate('transactionReference');
 
-        return array(
+        return [
             'transactionReference' => $this->getTransactionReference(),
-        );
+        ];
     }
 
     /**
-     * Send the request with specified data
+     * Send the request with specified data.
      *
-     * @param  mixed $data The data to send
+     * @param mixed $data The data to send
+     *
      * @return ResponseInterface
      */
     public function sendData($data)

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -2,6 +2,10 @@
 
 namespace Omnipay\Braintree;
 
+use Braintree\Digest;
+use Braintree\Version;
+use Braintree\Configuration;
+use Omnipay\Braintree\Gateway;
 use Omnipay\Tests\GatewayTestCase;
 
 class GatewayTest extends GatewayTestCase
@@ -145,10 +149,10 @@ class GatewayTest extends GatewayTestCase
 
     public function testParseNotification()
     {
-        if(\Braintree_Version::MAJOR >= 3) {
+        if(Version::MAJOR >= 3) {
             $xml = '<notification></notification>';
             $payload = base64_encode($xml);
-            $signature = \Braintree_Digest::hexDigestSha1(\Braintree_Configuration::privateKey(), $payload);
+            $signature = Digest::hexDigestSha1(Configuration::privateKey(), $payload);
             $gatewayMock = $this->buildGatewayMock($payload);
             $gateway = new Gateway($this->getHttpClient(), $this->getHttpRequest(), $gatewayMock);
             $params = array(
@@ -156,11 +160,11 @@ class GatewayTest extends GatewayTestCase
                 'bt_payload' => $payload
             );
             $request = $gateway->parseNotification($params);
-            $this->assertInstanceOf('\Braintree_WebhookNotification', $request);
+            $this->assertInstanceOf('\Braintree\WebhookNotification', $request);
         } else {
             $xml = '<notification><subject></subject></notification>';
             $payload = base64_encode($xml);
-            $signature = \Braintree_Digest::hexDigestSha1(\Braintree_Configuration::privateKey(), $payload);
+            $signature = Digest::hexDigestSha1(Configuration::privateKey(), $payload);
             $gatewayMock = $this->buildGatewayMock($payload);
             $gateway = new Gateway($this->getHttpClient(), $this->getHttpRequest(), $gatewayMock);
             $params = array(
@@ -168,18 +172,18 @@ class GatewayTest extends GatewayTestCase
                 'bt_payload' => $payload
             );
             $request = $gateway->parseNotification($params);
-            $this->assertInstanceOf('\Braintree_WebhookNotification', $request);
+            $this->assertInstanceOf('\Braintree\WebhookNotification', $request);
         }
     }
 
     /**
      * @param $payload
      *
-     * @return \Braintree_Gateway
+     * @return Gateway
      */
     protected function buildGatewayMock($payload)
     {
-        $configuration = $this->getMockBuilder('\Braintree_Configuration')
+        $configuration = $this->getMockBuilder('\Braintree\Configuration')
             ->disableOriginalConstructor()
             ->setMethods(array(
                 'assertHasAccessTokenOrKeys'
@@ -189,11 +193,9 @@ class GatewayTest extends GatewayTestCase
             ->method('assertHasAccessTokenOrKeys')
             ->will($this->returnValue(null));
 
-
-
         $configuration->setPublicKey($payload);
 
-        \Braintree_Configuration::$global = $configuration;
-        return \Braintree_Configuration::gateway();
+        Configuration::$global = $configuration;
+        return Configuration::gateway();
     }
 }

--- a/tests/MerchantFundingTest.php
+++ b/tests/MerchantFundingTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\Braintree;
 
-use Braintree_MerchantAccount;
+use Braintree\MerchantAccount;
 use Omnipay\Tests\TestCase;
 
 class MerchantFundingTest extends TestCase
@@ -29,7 +29,7 @@ class MerchantFundingTest extends TestCase
     {
         $card = new MerchantFunding(array(
             'descriptor' => 'Millsburg National Bank',
-            'destination' => Braintree_MerchantAccount::FUNDING_DESTINATION_BANK,
+            'destination' => MerchantAccount::FUNDING_DESTINATION_BANK,
             'email' => 'payment@hoochiesdollarstore.com',
             'mobilePhone' => '501.778.3151',
             'accountNumber' => '1123581321',
@@ -38,7 +38,7 @@ class MerchantFundingTest extends TestCase
 
         $parameters = $card->getParameters();
         $this->assertSame('Millsburg National Bank', $parameters['descriptor']);
-        $this->assertSame(Braintree_MerchantAccount::FUNDING_DESTINATION_BANK, $parameters['destination']);
+        $this->assertSame(MerchantAccount::FUNDING_DESTINATION_BANK, $parameters['destination']);
         $this->assertSame('payment@hoochiesdollarstore.com', $parameters['email']);
         $this->assertSame('501.778.3151', $parameters['mobilePhone']);
         $this->assertSame('1123581321', $parameters['accountNumber']);
@@ -71,8 +71,8 @@ class MerchantFundingTest extends TestCase
 
     public function testDestination()
     {
-        $this->funding->setDestination(Braintree_MerchantAccount::FUNDING_DESTINATION_BANK);
-        $this->assertEquals(Braintree_MerchantAccount::FUNDING_DESTINATION_BANK, $this->funding->getDestination());
+        $this->funding->setDestination(MerchantAccount::FUNDING_DESTINATION_BANK);
+        $this->assertEquals(MerchantAccount::FUNDING_DESTINATION_BANK, $this->funding->getDestination());
     }
 
     public function testEmail()

--- a/tests/Message/AbstractMerchantAccountRequestTest.php
+++ b/tests/Message/AbstractMerchantAccountRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
-use Braintree_MerchantAccount;
+use Braintree\MerchantAccount;
 use Mockery;
 use Omnipay\Tests\TestCase;
 
@@ -32,11 +32,11 @@ class AbstractMerchantAccountRequestTest extends TestCase
     }
 
     public function provideKeepsData(){
-        return array(
-            array('merchantAccountId', 'blue_ladders_store'),
-            array('masterMerchantAccountId', '14ladders_marketplace'),
-            array('tosAccepted', true),
-        );
+        return [
+            ['merchantAccountId', 'blue_ladders_store'],
+            ['masterMerchantAccountId', '14ladders_marketplace'],
+            ['tosAccepted', true],
+        ];
     }
 
     /**
@@ -62,7 +62,7 @@ class AbstractMerchantAccountRequestTest extends TestCase
 
     public function testBusinessData()
     {
-        $business = array(
+        $business = [
             'legalName' => 'Jane\'s Ladders',
             'dbaName' => 'Jane\'s Ladders',
             'taxId' => '98-7654321',
@@ -70,7 +70,7 @@ class AbstractMerchantAccountRequestTest extends TestCase
             'city' => 'Chicago',
             'state' => 'IL',
             'postCode' => '60622',
-        );
+        ];
 
         $this->request->setBusiness($business);
         $data = $this->request->getBusinessData();
@@ -88,7 +88,7 @@ class AbstractMerchantAccountRequestTest extends TestCase
     {
         $funding = array(
             'descriptor' => 'Blue Ladders',
-            'destination' => Braintree_MerchantAccount::FUNDING_DESTINATION_BANK,
+            'destination' => MerchantAccount::FUNDING_DESTINATION_BANK,
             'email' => 'funding@blueladders.com',
             'mobilePhone' => '5555555555',
             'accountNumber' => '1123581321',

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class AuthorizeRequestTest extends TestCase
@@ -15,7 +16,7 @@ class AuthorizeRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new AuthorizeRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new AuthorizeRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'amount' => '10.00',
@@ -48,7 +49,7 @@ class AuthorizeRequestTest extends TestCase
         $this->assertFalse(isset($data['billingAddressId']));
 
         $this->request->configure();
-        $this->assertSame('production', \Braintree_Configuration::environment());
+        $this->assertSame('production', Configuration::environment());
     }
 
     public function testPaymentMethodToken()
@@ -138,7 +139,7 @@ class AuthorizeRequestTest extends TestCase
         $this->request->setTestMode(true);
 
         $this->request->configure();
-        $this->assertSame('sandbox', \Braintree_Configuration::environment());
+        $this->assertSame('sandbox', Configuration::environment());
     }
 
     public function testServiceFeeAmount()
@@ -169,7 +170,7 @@ class AuthorizeRequestTest extends TestCase
     public function testGetServiceFeeAmountNoDecimalsRounding()
     {
         $this->markTestSkipped('Omnipay does not round the amount.');
-        
+
         $this->assertSame($this->request, $this->request->setServiceFeeAmount('136.5'));
         $this->assertSame($this->request, $this->request->setCurrency('JPY'));
         $this->assertSame('137', $this->request->getServiceFeeAmount());

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class CaptureRequestTest extends TestCase
@@ -15,7 +16,7 @@ class CaptureRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new CaptureRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new CaptureRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'amount' => '10.00',

--- a/tests/Message/ClientTokenRequestTest.php
+++ b/tests/Message/ClientTokenRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class ClientTokenRequestTest extends TestCase
@@ -15,7 +16,7 @@ class ClientTokenRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new ClientTokenRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new ClientTokenRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
     }
 
     public function testGetData()

--- a/tests/Message/ClientTokenResponseTest.php
+++ b/tests/Message/ClientTokenResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class ClientTokenResponseTest extends TestCase
@@ -15,7 +16,7 @@ class ClientTokenResponseTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new ClientTokenRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new ClientTokenRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
     }
 
     public function testSuccess()

--- a/tests/Message/CreateCustomerRequestTest.php
+++ b/tests/Message/CreateCustomerRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class CreateCustomerRequestTest extends TestCase
@@ -15,7 +16,7 @@ class CreateCustomerRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new CreateCustomerRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new CreateCustomerRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'customerData' => array(

--- a/tests/Message/CreateMerchantAccountRequestTest.php
+++ b/tests/Message/CreateMerchantAccountRequestTest.php
@@ -2,7 +2,8 @@
 
 namespace Omnipay\Braintree\Message;
 
-use Braintree_MerchantAccount;
+use Braintree\Configuration;
+use Braintree\MerchantAccount;
 use Omnipay\Tests\TestCase;
 
 class CreateMerchantAccountRequestTest extends TestCase
@@ -16,7 +17,7 @@ class CreateMerchantAccountRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new CreateMerchantAccountRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new CreateMerchantAccountRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'individual' => array(
@@ -42,7 +43,7 @@ class CreateMerchantAccountRequestTest extends TestCase
                 ),
                 'funding' => array(
                     'descriptor' => 'Blue Ladders',
-                    'destination' => Braintree_MerchantAccount::FUNDING_DESTINATION_BANK,
+                    'destination' => MerchantAccount::FUNDING_DESTINATION_BANK,
                     'email' => 'funding@blueladders.com',
                     'mobilePhone' => '5555555555',
                     'accountNumber' => '1123581321',
@@ -71,7 +72,7 @@ class CreateMerchantAccountRequestTest extends TestCase
             'funding' => array(
                 'accountNumber' => '1123581321',
                 'descriptor' => 'Blue Ladders',
-                'destination' => Braintree_MerchantAccount::FUNDING_DESTINATION_BANK,
+                'destination' => MerchantAccount::FUNDING_DESTINATION_BANK,
                 'email' => 'funding@blueladders.com',
                 'mobilePhone' => '5555555555',
                 'routingNumber' => '071101307',

--- a/tests/Message/CreatePaymentMethodRequestTest.php
+++ b/tests/Message/CreatePaymentMethodRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class CreatePaymentMethodRequestTest extends TestCase
@@ -59,6 +60,6 @@ class CreatePaymentMethodRequestTest extends TestCase
      */
     private function createPaymentMethodRequest()
     {
-        return new CreatePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        return new CreatePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
     }
 }

--- a/tests/Message/CustomerResponseTest.php
+++ b/tests/Message/CustomerResponseTest.php
@@ -5,6 +5,7 @@
  */
 
 namespace Omnipay\Braintree\Message;
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class CustomerResponseTest extends TestCase
@@ -18,7 +19,7 @@ class CustomerResponseTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new CreateCustomerRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new CreateCustomerRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
     }
 
     public function testGetSubscriptionData()

--- a/tests/Message/DeleteCustomerRequestTest.php
+++ b/tests/Message/DeleteCustomerRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class DeleteCustomerRequestTest extends TestCase
@@ -15,7 +16,7 @@ class DeleteCustomerRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new DeleteCustomerRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new DeleteCustomerRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'customerId' => '4815162342'

--- a/tests/Message/DeletePaymentMethodRequestTest.php
+++ b/tests/Message/DeletePaymentMethodRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Braintree\Message;
 
 use Omnipay\Tests\TestCase;
+use Braintree\Configuration;
 
 class DeletePaymentMethodRequestTest extends TestCase
 {
@@ -13,7 +14,7 @@ class DeletePaymentMethodRequestTest extends TestCase
 
     public function setUp()
     {
-        $this->request = new DeletePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new DeletePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'token' => 'abcd1234',

--- a/tests/Message/FindCustomerRequestTest.php
+++ b/tests/Message/FindCustomerRequestTest.php
@@ -35,14 +35,14 @@ class FindCustomerRequestTest extends TestCase
 
     protected function buildMockGateway()
     {
-        $gateway = $this->getMockBuilder('\Braintree_Gateway')
+        $gateway = $this->getMockBuilder('\Braintree\Gateway')
             ->disableOriginalConstructor()
             ->setMethods(array(
                 'customer'
             ))
             ->getMock();
 
-        $customer = $this->getMockBuilder('\Braintree_CustomerGateway')
+        $customer = $this->getMockBuilder('\Braintree\CustomerGateway')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Message/FindRequestTest.php
+++ b/tests/Message/FindRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class FindRequestTest extends TestCase
@@ -15,7 +16,7 @@ class FindRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new FindRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new FindRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'transactionReference' => 'abc123',

--- a/tests/Message/PlanRequestTest.php
+++ b/tests/Message/PlanRequestTest.php
@@ -40,14 +40,14 @@ class PlanRequestTest extends TestCase
 
     protected function buildMockGateway()
     {
-        $gateway = $this->getMockBuilder('\Braintree_Gateway')
+        $gateway = $this->getMockBuilder('\Braintree\Gateway')
             ->disableOriginalConstructor()
             ->setMethods(array(
                 'plan'
             ))
             ->getMock();
 
-        $plan = $this->getMockBuilder('\Braintree_PlanGateway')
+        $plan = $this->getMockBuilder('\Braintree\PlanGateway')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Message/PlanResponseTest.php
+++ b/tests/Message/PlanResponseTest.php
@@ -7,6 +7,8 @@
  */
 
 namespace Omnipay\Braintree\Message;
+
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class PlanResponseTest extends TestCase
@@ -19,7 +21,7 @@ class PlanResponseTest extends TestCase
         parent::setUp();
 
         $this->request = new PlanRequest(
-            $this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway()
+            $this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway()
         );
     }
 

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Braintree\Message;
 
 use Omnipay\Tests\TestCase;
+use Braintree\Configuration;
 
 class PurchaseRequestTest extends TestCase
 {
@@ -15,7 +16,7 @@ class PurchaseRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'amount' => '10.00',

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Braintree\Message;
 
 use Omnipay\Tests\TestCase;
+use Braintree\Configuration;
 
 class RefundRequestTest extends TestCase
 {
@@ -15,7 +16,7 @@ class RefundRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new RefundRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new RefundRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'amount' => '10.00',

--- a/tests/Message/ReleaseFromEscrowRequestTest.php
+++ b/tests/Message/ReleaseFromEscrowRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class ReleaseFromEscrowRequestTest extends TestCase
@@ -15,7 +16,7 @@ class ReleaseFromEscrowRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new ReleaseFromEscrowRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new ReleaseFromEscrowRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'transactionId' => 'abc123',

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -2,9 +2,10 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
+use Braintree\Result\Error;
+use Braintree\Result\Successful;
 use Omnipay\Tests\TestCase;
-use Braintree_Result_Successful;
-use Braintree_Result_Error;
 
 class ResponseTest extends TestCase
 {
@@ -17,12 +18,12 @@ class ResponseTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new AuthorizeRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new AuthorizeRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
     }
 
     public function testSuccess()
     {
-        $data = new Braintree_Result_Successful(1, 'transaction');
+        $data = new Successful(1, 'transaction');
 
         $response = new Response($this->request, $data);
 
@@ -33,7 +34,7 @@ class ResponseTest extends TestCase
 
     public function testError()
     {
-        $data = new Braintree_Result_Error(array('errors' => array(), 'params' => array(), 'message' => 'short message'));
+        $data = new Error(array('errors' => array(), 'params' => array(), 'message' => 'short message'));
 
         $response = new Response($this->request, $data);
 

--- a/tests/Message/SubscriptionResponseTest.php
+++ b/tests/Message/SubscriptionResponseTest.php
@@ -5,6 +5,8 @@
  */
 
 namespace Omnipay\Braintree\Message;
+
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class SubscriptionResponseTest extends TestCase
@@ -18,7 +20,7 @@ class SubscriptionResponseTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new CreateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new CreateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
     }
 
     public function testGetSubscriptionData()

--- a/tests/Message/UpdateCustomerRequestTest.php
+++ b/tests/Message/UpdateCustomerRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class UpdateCustomerRequestTest extends TestCase
@@ -15,7 +16,7 @@ class UpdateCustomerRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new UpdateCustomerRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new UpdateCustomerRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'customerId' => '4815162342',

--- a/tests/Message/UpdateMerchantAccountRequestTest.php
+++ b/tests/Message/UpdateMerchantAccountRequestTest.php
@@ -2,7 +2,8 @@
 
 namespace Omnipay\Braintree\Message;
 
-use Braintree_MerchantAccount;
+use Braintree\Configuration;
+use Braintree\MerchantAccount;
 use Omnipay\Tests\TestCase;
 
 class UpdateMerchantAccountRequestTest extends TestCase
@@ -16,7 +17,7 @@ class UpdateMerchantAccountRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new UpdateMerchantAccountRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new UpdateMerchantAccountRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'individual' => array(
@@ -42,7 +43,7 @@ class UpdateMerchantAccountRequestTest extends TestCase
                 ),
                 'funding' => array(
                     'descriptor' => 'Blue Ladders',
-                    'destination' => Braintree_MerchantAccount::FUNDING_DESTINATION_BANK,
+                    'destination' => MerchantAccount::FUNDING_DESTINATION_BANK,
                     'email' => 'funding@blueladders.com',
                     'mobilePhone' => '5555555555',
                     'accountNumber' => '1123581321',
@@ -71,7 +72,7 @@ class UpdateMerchantAccountRequestTest extends TestCase
                 'funding' => array(
                     'accountNumber' => '1123581321',
                     'descriptor' => 'Blue Ladders',
-                    'destination' => Braintree_MerchantAccount::FUNDING_DESTINATION_BANK,
+                    'destination' => MerchantAccount::FUNDING_DESTINATION_BANK,
                     'email' => 'funding@blueladders.com',
                     'mobilePhone' => '5555555555',
                     'routingNumber' => '071101307',

--- a/tests/Message/UpdatePaymentMethodRequestTest.php
+++ b/tests/Message/UpdatePaymentMethodRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class UpdatePaymentMethodRequestTest extends TestCase
@@ -13,7 +14,7 @@ class UpdatePaymentMethodRequestTest extends TestCase
 
     public function setUp()
     {
-        $this->request = new UpdatePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new UpdatePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
     }
 
     public function testGetData()

--- a/tests/Message/VoidRequestTest.php
+++ b/tests/Message/VoidRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Braintree\Message;
 
+use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
 
 class VoidRequestTest extends TestCase
@@ -15,7 +16,7 @@ class VoidRequestTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = new VoidRequest($this->getHttpClient(), $this->getHttpRequest(), \Braintree_Configuration::gateway());
+        $this->request = new VoidRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(
             array(
                 'transactionReference' => 'abc123',


### PR DESCRIPTION
Removes prior support for older versions of php to allow the use of the current braintree PHP SDK.