### PR TITLE
Add the keys to the UpdatePaymentMethodRequest data

### DIFF
--- a/src/Message/UpdatePaymentMethodRequest.php
+++ b/src/Message/UpdatePaymentMethodRequest.php
@@ -20,6 +20,14 @@ class UpdatePaymentMethodRequest extends AbstractRequest
             $data['options'] = $options;
         }
 
+        foreach (array('cardholderName', 'expirationDate') as $key) {
+            $value = $this->parameters->get($key);
+
+            if (null !== $value) {
+                $data[$key] = $value;
+            }
+        }
+
         return $data;
     }
 
@@ -65,5 +73,25 @@ class UpdatePaymentMethodRequest extends AbstractRequest
     public function setOptions(array $options = array())
     {
         return $this->setParameter('paymentMethodOptions', $options);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setCardholderName($value)
+    {
+        return $this->setParameter('cardholderName', $value);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setExpirationDate($value)
+    {
+        return $this->setParameter('expirationDate', $value);
     }
 }

--- a/tests/Message/UpdatePaymentMethodRequestTest.php
+++ b/tests/Message/UpdatePaymentMethodRequestTest.php
@@ -21,6 +21,8 @@ class UpdatePaymentMethodRequestTest extends TestCase
         $this->request->initialize(
             array(
                 'paymentMethodToken' => 'abcd1234',
+                'cardholderName' => 'John Doe',
+                'expirationDate' => '06/2030',
                 'options' => array(
                     'makeDefault' => true,
                 )
@@ -31,6 +33,8 @@ class UpdatePaymentMethodRequestTest extends TestCase
             'options' => array(
                 'makeDefault' => true,
             ),
+            'cardholderName' => 'John Doe',
+            'expirationDate' => '06/2030',
         );
         $this->assertSame($expected, $this->request->getData());
     }


### PR DESCRIPTION
There's quite a few additional keys that Braintree accepts as part of its Update payment method endpoint (https://developers.braintreepayments.com/reference/request/payment-method/update/php#arg.token). I'm adding `cardholderName` and `expirationDate` because those are keys that I need at the moment; I'd like to keep the LoC low for this first PR, but I can also add the other missing keys if necessary.

- [x] Fork the project.
- [x] Make your feature addition or bug fix.
- [x] Add tests for it. This is important so I don't break it in a future version unintentionally.
    - Note: I updated existing tests, but if you prefer new tests to get written I can do that as well
- [x] Commit just the modifications, do not mess with the composer.json or CHANGELOG.md files.
- [x] Ensure your code is nicely formatted in the PSR-2 style and that all tests pass.
- [x] Send the pull request.
- [x] Check that the Travis CI build passed. If not, rinse and repeat.