### PR TITLE
adds reference to the 3.0 branch for earlier versions of PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Total Downloads](https://poser.pugx.org/omnipay/braintree/d/total.png)](https://packagist.org/packages/omnipay/braintree)
 
 [Omnipay](https://github.com/thephpleague/omnipay) is a framework agnostic, multi-gateway payment
-processing library for PHP 7.2+. This package implements Braintree support for Omnipay.
+processing library for PHP 5.3+. This package implements Braintree support for Omnipay.
 
 ## Installation
 
@@ -16,6 +16,11 @@ to your `composer.json` file:
 
 ```
 composer require omnipay/braintree:"~4.0@dev"
+```
+
+For PHP versions 5.3 to 7.1.x
+```
+composer require omnipay/braintree:"~3.0@dev"
 ```
 
 ## Basic Usage


### PR DESCRIPTION
I believe the 4.0 tag needs to be setup in packagist, I think leaving the 3.0 one in the readme may be good for developers using older versions of PHP.