### PR TITLE
Adds support for transaction line items with descriptions

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -428,6 +428,40 @@ abstract class AbstractRequest extends BaseAbstractRequest
         }
     }
 
+    /**
+     * @return array
+     */
+    public function getLineItems()
+    {
+        $line_items = array();
+
+        if (! $this->getItems()) {
+            return $line_items;
+        }
+
+        foreach ($items as $item) {
+
+            $item_kind = ($item->getPrice() >= 0.00)
+                ? 'debit'
+                : 'credit';
+
+            $unit_amount = ($item->getQuantity() > 0)
+                ? $item->getPrice() / $item->getQuantity()
+                : $item->getPrice();
+
+            array_push($line_items, array(
+                'name' => $item->getName(),
+                'description' => $item->getDescription(),
+                'totalAmount' => $item->getPrice(),
+                'unitAmount' => $unit_amount,
+                'kind' => $item_kind,
+                'quantity' => $item->getQuantity(),
+            ));
+        }
+
+        return $line_items;
+    }
+ 
     protected function createResponse($data)
     {
         return $this->response = new Response($this, $data);

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -452,8 +452,8 @@ abstract class AbstractRequest extends BaseAbstractRequest
             array_push($line_items, array(
                 'name' => $item->getName(),
                 'description' => $item->getDescription(),
-                'totalAmount' => $item->getPrice(),
-                'unitAmount' => $unit_amount,
+                'totalAmount' => abs($item->getPrice()),
+                'unitAmount' => abs($unit_amount),
                 'kind' => $item_kind,
                 'quantity' => $item->getQuantity(),
             ));

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -32,6 +32,7 @@ class AuthorizeRequest extends AbstractRequest
             'shippingAddressId' => $this->getShippingAddressId(),
             'taxAmount' => $this->getTaxAmount(),
             'taxExempt' => $this->getTaxExempt(),
+            'lineItems' => $this->getLineItems(),
         ];
 
         // special validation


### PR DESCRIPTION
Using the built in Items class in omni pay, we can add descriptive line items to a braintree transaction.  These items will appear in the braintree admin panel and on Paypal receipts.