### PR TITLE
Fixes to allow handling of regular credit card transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following gateways are provided by this package:
 
 You need to set your `merchantId`, `publicKey` and `privateKey`. Setting `testMode` to true will use the `sandbox` environment.
 
-This gateway supports purchase through a token (payment nonce) only. You can generate a clientToken for Javascript:
+This gateway supports purchase through a token (payment nonce), which is the method recommended by Braintree. You can generate a clientToken for Javascript:
 
 ```php
 $clientToken = $gateway->clientToken()->send()->getToken();
@@ -42,6 +42,20 @@ Use the `payment_method_nonce` to process your customer order like so:
 $response = $gateway->purchase([
             'amount' => '10.00',
             'token' => $_POST['payment_method_nonce']
+        ])->send();
+```
+
+It also supports making purchases when the credit card number is specified:
+
+```php
+$response = $gateway->purchase([
+            'amount' => '10.00',
+            'card' => [
+                'number' => '4111111111111111',
+                'expiryMonth' => '6',
+                'expiryYear' => '2025',
+                'cvv' => '123',
+            ]
         ])->send();
 ```
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -373,30 +373,40 @@ abstract class AbstractRequest extends BaseAbstractRequest
             return [];
         }
 
-        return [
-            'billing' => [
-                'company' => $card->getBillingCompany(),
-                'firstName' => $card->getBillingFirstName(),
-                'lastName' => $card->getBillingLastName(),
-                'streetAddress' => $card->getBillingAddress1(),
-                'extendedAddress' => $card->getBillingAddress2(),
-                'locality' => $card->getBillingCity(),
-                'postalCode' => $card->getBillingPostcode(),
-                'region' => $card->getBillingState(),
-                'countryName' => $card->getBillingCountry(),
-            ],
-            'shipping' => [
-                'company' => $card->getShippingCompany(),
-                'firstName' => $card->getShippingFirstName(),
-                'lastName' => $card->getShippingLastName(),
-                'streetAddress' => $card->getShippingAddress1(),
-                'extendedAddress' => $card->getShippingAddress2(),
-                'locality' => $card->getShippingCity(),
-                'postalCode' => $card->getShippingPostcode(),
-                'region' => $card->getShippingState(),
-                'countryName' => $card->getShippingCountry(),
-            ],
+        $number = $card->getNumber();
+        if ($number) {
+            $cardData['creditCard'] = [
+                'number' => $number,
+                'expirationDate' => sprintf('%s/%s', $card->getExpiryMonth(), $card->getExpiryYear()),
+                'cvv' => $card->getCvv(),
+            ];
+        }
+
+        $cardData['billing'] = [
+            'company' => $card->getBillingCompany(),
+            'firstName' => $card->getBillingFirstName(),
+            'lastName' => $card->getBillingLastName(),
+            'streetAddress' => $card->getBillingAddress1(),
+            'extendedAddress' => $card->getBillingAddress2(),
+            'locality' => $card->getBillingCity(),
+            'postalCode' => $card->getBillingPostcode(),
+            'region' => $card->getBillingState(),
+            'countryName' => $card->getBillingCountry(),
         ];
+
+        $cardData['shipping'] = [
+            'company' => $card->getShippingCompany(),
+            'firstName' => $card->getShippingFirstName(),
+            'lastName' => $card->getShippingLastName(),
+            'streetAddress' => $card->getShippingAddress1(),
+            'extendedAddress' => $card->getShippingAddress2(),
+            'locality' => $card->getShippingCity(),
+            'postalCode' => $card->getShippingPostcode(),
+            'region' => $card->getShippingState(),
+            'countryName' => $card->getShippingCountry(),
+        ];
+
+        return $cardData;
     }
 
     /**
@@ -461,7 +471,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
 
         return $line_items;
     }
- 
+
     protected function createResponse($data)
     {
         return $this->response = new Response($this, $data);

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -35,15 +35,20 @@ class AuthorizeRequest extends AbstractRequest
             'lineItems' => $this->getLineItems(),
         ];
 
-        // special validation
-        if ($this->getPaymentMethodToken()) {
-            $data['paymentMethodToken'] = $this->getPaymentMethodToken();
-        } elseif ($this->getToken()) {
-            $data['paymentMethodNonce'] = $this->getToken();
-        } elseif ($this->getCustomerId()) {
-            $data['customerId'] = $this->getCustomerId();
-        } else {
-            throw new InvalidRequestException('The token (payment nonce), paymentMethodToken or customerId field should be set.');
+        $cardData = $this->getCardData();
+
+        if (empty($cardData['creditCard']['number'])) {
+            // special validation if the card number
+            // is not specified
+            if ($this->getPaymentMethodToken()) {
+                $data['paymentMethodToken'] = $this->getPaymentMethodToken();
+            } elseif ($this->getToken()) {
+                $data['paymentMethodNonce'] = $this->getToken();
+            } elseif ($this->getCustomerId()) {
+                $data['customerId'] = $this->getCustomerId();
+            } else {
+                throw new InvalidRequestException('The token (payment nonce), paymentMethodToken or customerId field should be set.');
+            }
         }
 
         // Remove null values
@@ -58,7 +63,7 @@ class AuthorizeRequest extends AbstractRequest
         }
 
         $data += $this->getOptionData();
-        $data += $this->getCardData();
+        $data += $cardData;
         $data['options']['submitForSettlement'] = false;
 
         return $data;


### PR DESCRIPTION
I've been using the Braintree API directly and decided to migrate our credit card processing code to Omnipay.

I was surprised to discover that Omnipay/Braintree only supports transactions using a nonce and did not handle traditional processing where the card number is available.

This pull requests fixes that problem.  All the nonce stuff still works, but now it can also handle regular card transactions.