### PR TITLE
Add merchantAccountId parameter to ClientTokenRequest

### DIFF
--- a/src/Message/ClientTokenRequest.php
+++ b/src/Message/ClientTokenRequest.php
@@ -16,6 +16,11 @@ class ClientTokenRequest extends AbstractRequest
         if ($customerId = $this->getCustomerId()) {
             $data['customerId'] = $customerId;
         }
+        
+        if ($merchantAccountId = $this->getMerchantAccountId()) {
+            $data['merchantAccountId'] = $merchantAccountId;
+        }
+        
         $data += $this->getOptionData();
 
         return $data;


### PR DESCRIPTION
Merchant Account ID is a required parameter for 3DS2 support in client token requests. This commit adds the required functionality.