### PR TITLE
Fix bug in d947113 where `$items` is not defined

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -435,7 +435,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
     {
         $line_items = array();
 
-        if (! $this->getItems()) {
+        if (!$items = $this->getItems()) {
             return $line_items;
         }
 
@@ -461,7 +461,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
 
         return $line_items;
     }
- 
+
     protected function createResponse($data)
     {
         return $this->response = new Response($this, $data);


### PR DESCRIPTION
Resolves #67 

This fixes a critical bug introduced by d947113 which caused an `Undefined variable $items` to be output from line 442 of `src/Message/AbstractRequest.php`.

https://github.com/thephpleague/omnipay-braintree/blob/d9471135a2837476687ad7f24e8656c92ce64088/src/Message/AbstractRequest.php#L438-L442