### PR TITLE
Fix bug where `$item->getPrice()` was being used as the total amount …

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -445,15 +445,11 @@ abstract class AbstractRequest extends BaseAbstractRequest
                 ? 'debit'
                 : 'credit';
 
-            $unit_amount = ($item->getQuantity() > 0)
-                ? $item->getPrice() / $item->getQuantity()
-                : $item->getPrice();
-
             array_push($line_items, array(
                 'name' => $item->getName(),
                 'description' => $item->getDescription(),
-                'totalAmount' => abs($item->getPrice()),
-                'unitAmount' => abs($unit_amount),
+                'totalAmount' => abs(round($item->getQuantity() * $item->getPrice(), $this->getCurrencyDecimalPlaces())),
+                'unitAmount' => abs(round($item->getPrice(), $this->getCurrencyDecimalPlaces())),
                 'kind' => $item_kind,
                 'quantity' => $item->getQuantity(),
             ));


### PR DESCRIPTION
…rather than the unit amount

see https://github.com/thephpleague/omnipay-braintree/issues/69