### PR TITLE
Braintree 6x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: php
 sudo: false
 
 php:
-  - 7.2
+  - 7.3
+  - 8.2
 
 before_script:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Total Downloads](https://poser.pugx.org/omnipay/braintree/d/total.png)](https://packagist.org/packages/omnipay/braintree)
 
 [Omnipay](https://github.com/thephpleague/omnipay) is a framework agnostic, multi-gateway payment
-processing library for PHP 7.2+. This package implements Braintree support for Omnipay.
+processing library for PHP 7.3+. This package implements Braintree support for Omnipay.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
     },
     "require": {
         "omnipay/common": "^3",
-        "braintree/braintree_php": "^5.0"
+        "braintree/braintree_php": "^6.0"
     },
     "require-dev": {
-        "omnipay/tests": "^3"
+        "omnipay/tests": "^4"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
-    <testsuites>
-        <testsuite name="Omnipay Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    convertWarningsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertErrorsToExceptions="true"
+    bootstrap="vendor/autoload.php"
+    backupStaticAttributes="false"
+    processIsolation="false"
+    stopOnFailure="false"
+    backupGlobals="false"
+    colors="true">
+  <coverage>
+    <include>
+      <directory>./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Omnipay Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/MerchantIndividual.php
+++ b/src/MerchantIndividual.php
@@ -184,7 +184,7 @@ class MerchantIndividual
     {
         $names = explode(' ', $value, 2);
         $this->setFirstName($names[0]);
-        $this->setLastName(isset($names[1]) ? $names[1] : null);
+        $this->setLastName($names[1] ?? null);
 
         return $this;
     }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -159,16 +159,6 @@ abstract class AbstractRequest extends BaseAbstractRequest
         return $this->setParameter('deviceData', $value);
     }
 
-    public function getDeviceSessionId()
-    {
-        return $this->getParameter('deviceSessionId');
-    }
-
-    public function setDeviceSessionId($value)
-    {
-        return $this->setParameter('deviceSessionId', $value);
-    }
-
     public function getMerchantAccountId()
     {
         return $this->getParameter('merchantAccountId');

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -23,7 +23,6 @@ class AuthorizeRequest extends AbstractRequest
             'customerId' => $this->getCustomerId(),
             'descriptor' => $this->getDescriptor(),
             'deviceData' => $this->getDeviceData(),
-            'deviceSessionId' => $this->getDeviceSessionId(),
             'merchantAccountId' => $this->getMerchantAccountId(),
             'orderId' => $this->getTransactionId(),
             'purchaseOrderNumber' => $this->getPurchaseOrderNumber(),

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -15,6 +15,11 @@ class GatewayTest extends GatewayTestCase
      */
     protected $gateway;
 
+    /**
+     * @var array
+     */
+    protected $options;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -150,30 +155,21 @@ class GatewayTest extends GatewayTestCase
     public function testParseNotification()
     {
         if(Version::MAJOR >= 3) {
-            $xml = '<notification></notification>';
-            $payload = base64_encode($xml);
-            $signature = Digest::hexDigestSha1(Configuration::privateKey(), $payload);
-            $gatewayMock = $this->buildGatewayMock($payload);
-            $gateway = new Gateway($this->getHttpClient(), $this->getHttpRequest(), $gatewayMock);
-            $params = array(
-                'bt_signature' => $payload.'|'.$signature,
-                'bt_payload' => $payload
-            );
-            $request = $gateway->parseNotification($params);
-            $this->assertInstanceOf('\Braintree\WebhookNotification', $request);
+            $xml = '<notification><subject></subject><kind></kind></notification>';
         } else {
             $xml = '<notification><subject></subject></notification>';
-            $payload = base64_encode($xml);
-            $signature = Digest::hexDigestSha1(Configuration::privateKey(), $payload);
-            $gatewayMock = $this->buildGatewayMock($payload);
-            $gateway = new Gateway($this->getHttpClient(), $this->getHttpRequest(), $gatewayMock);
-            $params = array(
-                'bt_signature' => $payload.'|'.$signature,
-                'bt_payload' => $payload
-            );
-            $request = $gateway->parseNotification($params);
-            $this->assertInstanceOf('\Braintree\WebhookNotification', $request);
         }
+
+        $payload = base64_encode($xml);
+        $signature = Digest::hexDigestSha1(Configuration::privateKey(), $payload);
+        $gatewayMock = $this->buildGatewayMock($payload);
+        $gateway = new Gateway($this->getHttpClient(), $this->getHttpRequest(), $gatewayMock);
+        $params = array(
+            'bt_signature' => $payload.'|'.$signature,
+            'bt_payload' => $payload
+        );
+        $request = $gateway->parseNotification($params);
+        $this->assertInstanceOf('\Braintree\WebhookNotification', $request);
     }
 
     /**

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -15,7 +15,7 @@ class GatewayTest extends GatewayTestCase
      */
     protected $gateway;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/MerchantBusinessTest.php
+++ b/tests/MerchantBusinessTest.php
@@ -8,7 +8,7 @@ use Omnipay\Tests\TestCase;
 
 class MerchantBusinessTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->business = new MerchantBusiness();
     }

--- a/tests/MerchantBusinessTest.php
+++ b/tests/MerchantBusinessTest.php
@@ -8,6 +8,11 @@ use Omnipay\Tests\TestCase;
 
 class MerchantBusinessTest extends TestCase
 {
+    /**
+     * @var MerchantBusiness
+     */
+    protected $business;
+
     public function setUp(): void
     {
         $this->business = new MerchantBusiness();

--- a/tests/MerchantFundingTest.php
+++ b/tests/MerchantFundingTest.php
@@ -7,7 +7,7 @@ use Omnipay\Tests\TestCase;
 
 class MerchantFundingTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->funding = new MerchantFunding();
     }

--- a/tests/MerchantFundingTest.php
+++ b/tests/MerchantFundingTest.php
@@ -7,6 +7,11 @@ use Omnipay\Tests\TestCase;
 
 class MerchantFundingTest extends TestCase
 {
+    /**
+     * @var MerchantFunding
+     */
+    protected $funding;
+
     public function setUp(): void
     {
         $this->funding = new MerchantFunding();

--- a/tests/MerchantIndividualTest.php
+++ b/tests/MerchantIndividualTest.php
@@ -8,7 +8,7 @@ use Omnipay\Tests\TestCase;
 
 class MerchantIndividualTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->individual = new MerchantIndividual();
     }

--- a/tests/MerchantIndividualTest.php
+++ b/tests/MerchantIndividualTest.php
@@ -8,6 +8,11 @@ use Omnipay\Tests\TestCase;
 
 class MerchantIndividualTest extends TestCase
 {
+    /**
+     * @var MerchantIndividual
+     */
+    protected $individual;
+
     public function setUp(): void
     {
         $this->individual = new MerchantIndividual();

--- a/tests/Message/AbstractMerchantAccountRequestTest.php
+++ b/tests/Message/AbstractMerchantAccountRequestTest.php
@@ -13,7 +13,7 @@ class AbstractMerchantAccountRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->request = Mockery::mock('\Omnipay\Braintree\Message\AbstractMerchantAccountRequest')->makePartial();
         $this->request->initialize();

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -12,7 +12,7 @@ class AbstractRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->request = Mockery::mock('\Omnipay\Braintree\Message\AbstractRequest')->makePartial();
         $this->request->initialize();

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -42,7 +42,6 @@ class AbstractRequestTest extends TestCase
             array('customerId', 'abc123'),
             array('descriptor', array('a' => 'b')),
             array('deviceData', 'abc123'),
-            array('deviceSessionId', 'abc123'),
             array('merchantAccountId', 'abc123'),
             array('recurring', true),
             array('addBillingAddressToPaymentMethod', true),

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -4,6 +4,7 @@ namespace Omnipay\Braintree\Message;
 
 use Braintree\Configuration;
 use Omnipay\Tests\TestCase;
+use Omnipay\Common\Exception\InvalidRequestException;
 
 class AuthorizeRequestTest extends TestCase
 {
@@ -176,23 +177,24 @@ class AuthorizeRequestTest extends TestCase
         $this->assertSame('137', $this->request->getServiceFeeAmount());
     }
 
-    /**
-     * @expectedException \Omnipay\Common\Exception\InvalidRequestException
-     */
     public function testServiceFeeAmountWithIntThrowsException()
     {
         // ambiguous value, avoid errors upgrading from v0.9
         $this->assertSame($this->request, $this->request->setServiceFeeAmount(10));
+
+        $this->expectException(InvalidRequestException::class);
+
         $this->request->getServiceFeeAmount();
+
     }
 
-    /**
-     * @expectedException \Omnipay\Common\Exception\InvalidRequestException
-     */
     public function testServiceFeeAmountWithIntStringThrowsException()
     {
         // ambiguous value, avoid errors upgrading from v0.9
         $this->assertSame($this->request, $this->request->setServiceFeeAmount('10'));
+
+        $this->expectException(InvalidRequestException::class);
+
         $this->request->getServiceFeeAmount();
     }
 }

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -12,7 +12,7 @@ class AuthorizeRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -12,7 +12,7 @@ class CaptureRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/ClientTokenRequestTest.php
+++ b/tests/Message/ClientTokenRequestTest.php
@@ -12,7 +12,7 @@ class ClientTokenRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/ClientTokenResponseTest.php
+++ b/tests/Message/ClientTokenResponseTest.php
@@ -12,7 +12,7 @@ class ClientTokenResponseTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/CreateCustomerRequestTest.php
+++ b/tests/Message/CreateCustomerRequestTest.php
@@ -12,7 +12,7 @@ class CreateCustomerRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/CreateMerchantAccountRequestTest.php
+++ b/tests/Message/CreateMerchantAccountRequestTest.php
@@ -13,7 +13,7 @@ class CreateMerchantAccountRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/CustomerResponseTest.php
+++ b/tests/Message/CustomerResponseTest.php
@@ -15,7 +15,7 @@ class CustomerResponseTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/DeleteCustomerRequestTest.php
+++ b/tests/Message/DeleteCustomerRequestTest.php
@@ -12,7 +12,7 @@ class DeleteCustomerRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/DeletePaymentMethodRequestTest.php
+++ b/tests/Message/DeletePaymentMethodRequestTest.php
@@ -12,7 +12,7 @@ class DeletePaymentMethodRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->request = new DeletePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
         $this->request->initialize(

--- a/tests/Message/FindCustomerRequestTest.php
+++ b/tests/Message/FindCustomerRequestTest.php
@@ -10,7 +10,7 @@ class FindCustomerRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/FindRequestTest.php
+++ b/tests/Message/FindRequestTest.php
@@ -12,7 +12,7 @@ class FindRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/PlanRequestTest.php
+++ b/tests/Message/PlanRequestTest.php
@@ -15,7 +15,7 @@ class PlanRequestTest extends TestCase
     /** @var PlanRequest */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/PlanResponseTest.php
+++ b/tests/Message/PlanResponseTest.php
@@ -16,7 +16,7 @@ class PlanResponseTest extends TestCase
     /** @var  PlanRequest */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -12,7 +12,7 @@ class PurchaseRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -12,7 +12,7 @@ class RefundRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/ReleaseFromEscrowRequestTest.php
+++ b/tests/Message/ReleaseFromEscrowRequestTest.php
@@ -12,7 +12,7 @@ class ReleaseFromEscrowRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -14,7 +14,7 @@ class ResponseTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/SubscriptionResponseTest.php
+++ b/tests/Message/SubscriptionResponseTest.php
@@ -16,7 +16,7 @@ class SubscriptionResponseTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/UpdateCustomerRequestTest.php
+++ b/tests/Message/UpdateCustomerRequestTest.php
@@ -12,7 +12,7 @@ class UpdateCustomerRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/UpdateMerchantAccountRequestTest.php
+++ b/tests/Message/UpdateMerchantAccountRequestTest.php
@@ -13,7 +13,7 @@ class UpdateMerchantAccountRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/UpdatePaymentMethodRequestTest.php
+++ b/tests/Message/UpdatePaymentMethodRequestTest.php
@@ -12,7 +12,7 @@ class UpdatePaymentMethodRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->request = new UpdatePaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest(), Configuration::gateway());
     }

--- a/tests/Message/VoidRequestTest.php
+++ b/tests/Message/VoidRequestTest.php
@@ -12,7 +12,7 @@ class VoidRequestTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Closes #74 

Please review this pull request and help move this project to version 6.x of the Braintree PHP SDK. Version 5.x of the SDK is deprecated as of March 2023 so it would be nice to get this integration up to date.